### PR TITLE
add parse method

### DIFF
--- a/time.go
+++ b/time.go
@@ -9,17 +9,27 @@ import (
 	"time"
 )
 
-const layout = "2006-01-02T15:04:05.999Z"
+const Layout = "2006-01-02T15:04:05.999Z"
 
 type Time struct {
 	time.Time
+}
+
+// Parse a string into an ISO8601 time.
+// Returns an error if the string is not in ISO8601 format.
+func Parse(value string) (Time, error) {
+	nt, err := time.Parse(Layout, value)
+	if err != nil {
+		return Time{}, err
+	}
+	return Time{nt}, nil
 }
 
 // UnmarshalJSON Parses the json string in the custom format
 func (ct *Time) UnmarshalJSON(b []byte) (err error) {
 	s := strings.Trim(string(b), `"`)
 
-	nt, err := time.Parse(layout, s)
+	nt, err := time.Parse(Layout, s)
 
 	*ct = Time{nt}
 	return
@@ -33,7 +43,7 @@ func (ct Time) MarshalJSON() ([]byte, error) {
 
 // String returns the time in ISO8601 format
 func (ct Time) String() string {
-	return ct.Time.UTC().Format(layout)
+	return ct.Time.UTC().Format(Layout)
 }
 
 // New creates a new ISO8601 Time from a standard Go time.


### PR DESCRIPTION
`iso8601.Parse(s)` will try and parse a string in ISO8601 format.